### PR TITLE
🏗️ Build spider: Newark Municipal Council

### DIFF
--- a/city_scrapers/spiders/newnj_nmc.py
+++ b/city_scrapers/spiders/newnj_nmc.py
@@ -1,0 +1,38 @@
+from city_scrapers_core.constants import CITY_COUNCIL
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import LegistarSpider
+
+
+class NewnjSpider(LegistarSpider):
+    name = "newnj_nmc"
+    agency = "Newark Municipal Council"
+    timezone = "America/Chicago"
+    start_urls = ["https://newark.legistar.com/Calendar.aspx"]
+    location = {
+        "address": "City Hall, 920 Broad Street, Newark, NJ 07102",
+        "name": "Municipal Council Chamber",
+    }
+
+    def parse_legistar(self, events):
+        """
+        `parse_legistar` should always `yield` Meeting items.
+
+        Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
+        needs.
+        """
+        for event in events:
+            meeting = Meeting(
+                title=event["Name"]["label"],
+                description="",
+                classification=CITY_COUNCIL,
+                start=self.legistar_start(event),
+                end=None,
+                all_day=False,
+                time_notes="",
+                location=self.location,
+                links=self.legistar_links(event),
+                source=self.legistar_source(event),
+            )
+            meeting["status"] = self._get_status(meeting)
+            meeting["id"] = self._get_id(meeting)
+            yield meeting

--- a/city_scrapers/spiders/newnj_nmc.py
+++ b/city_scrapers/spiders/newnj_nmc.py
@@ -31,7 +31,7 @@ class NewnjSpider(LegistarSpider):
                 time_notes="",
                 location=self.parse_location(event),
                 links=self.legistar_links(event),
-                source=self.legistar_source(event),
+                source=event["Meeting Details"]["url"],
             )
             meeting["status"] = self._get_status(meeting)
             meeting["id"] = self._get_id(meeting)

--- a/city_scrapers/spiders/newnj_nmc.py
+++ b/city_scrapers/spiders/newnj_nmc.py
@@ -6,7 +6,7 @@ from city_scrapers_core.spiders import LegistarSpider
 class NewnjSpider(LegistarSpider):
     name = "newnj_nmc"
     agency = "Newark Municipal Council"
-    timezone = "America/Chicago"
+    timezone = "America/New_York"
     start_urls = ["https://newark.legistar.com/Calendar.aspx"]
     location = {
         "address": "City Hall, 920 Broad Street, Newark, NJ 07102",

--- a/city_scrapers/spiders/newnj_nmc.py
+++ b/city_scrapers/spiders/newnj_nmc.py
@@ -8,7 +8,7 @@ class NewnjSpider(LegistarSpider):
     agency = "Newark Municipal Council"
     timezone = "America/New_York"
     start_urls = ["https://newark.legistar.com/Calendar.aspx"]
-    location = {
+    default_location = {
         "address": "City Hall, 920 Broad Street, Newark, NJ 07102",
         "name": "Municipal Council Chamber",
     }
@@ -29,10 +29,22 @@ class NewnjSpider(LegistarSpider):
                 end=None,
                 all_day=False,
                 time_notes="",
-                location=self.location,
+                location=self.parse_location(event),
                 links=self.legistar_links(event),
                 source=self.legistar_source(event),
             )
             meeting["status"] = self._get_status(meeting)
             meeting["id"] = self._get_id(meeting)
             yield meeting
+
+    def parse_location(self, event):
+        """
+        Parse or generate location.
+        """
+        location = event["Meeting Location"]
+        if "Council Chamber" in location:
+            return self.default_location
+        return {
+            "address": location,
+            "name": "",
+        }

--- a/tests/files/newnj_nmc.json
+++ b/tests/files/newnj_nmc.json
@@ -1,0 +1,29 @@
+[
+  {
+    "Name": {
+      "label": "Municipal Council",
+      "url": "https://newark.legistar.com/DepartmentDetail.aspx?ID=689&GUID=B3DBDA39-751C-4DD8-B443-ACC982CBFF09"
+    },
+    "Meeting Date": "4/10/2024",
+    "iCalendar": {
+      "url": "https://newark.legistar.com/View.ashx?M=IC&ID=1189588&GUID=C695B36D-A796-47DD-8140-118B4FFBA77F"
+    },
+    "Meeting Time": "12:30 PM",
+    "Meeting Location": "Council Chamber",
+    "Meeting Details": {
+      "label": "Meeting\u00a0details",
+      "url": "https://newark.legistar.com/MeetingDetail.aspx?ID=1189588&GUID=C695B36D-A796-47DD-8140-118B4FFBA77F&Options=info|&Search="
+    },
+    "Agenda": {
+      "label": "Agenda",
+      "url": "https://newark.legistar.com/View.ashx?M=A&ID=1189588&GUID=C695B36D-A796-47DD-8140-118B4FFBA77F"
+    },
+    "Accessible Agenda": {
+      "label": "Accessible Agenda",
+      "url": "https://newark.legistar.com/View.ashx?M=AADA&ID=1189588&GUID=C695B36D-A796-47DD-8140-118B4FFBA77F"
+    },
+    "Minutes": "Not\u00a0available",
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available"
+  }
+]

--- a/tests/test_newnj_nmc.py
+++ b/tests/test_newnj_nmc.py
@@ -1,0 +1,88 @@
+import json
+from datetime import datetime
+from os.path import dirname, join
+
+import pytest
+from city_scrapers_core.constants import CITY_COUNCIL, TENTATIVE
+from freezegun import freeze_time
+
+from city_scrapers.spiders.newnj_nmc import NewnjSpider
+
+freezer = freeze_time("2024-04-10")
+freezer.start()
+
+with open(
+    join(dirname(__file__), "files", "newnj_nmc.json"), "r", encoding="utf-8"
+) as f:  # noqa
+    test_response = json.load(f)
+
+spider = NewnjSpider()
+parsed_items = [item for item in spider.parse_legistar(test_response)]
+
+freezer.stop()
+
+
+def test_title():
+    assert parsed_items[0]["title"] == "Municipal Council"
+
+
+def test_description():
+    assert (
+        parsed_items[0]["description"] == ""
+    )  # Assuming description isn't provided directly  # noqa
+
+
+def test_start():
+    assert parsed_items[0]["start"] == datetime(2024, 4, 10, 12, 30)
+
+
+def test_end():
+    # Assuming the end time is not calculated and thus not provided
+    assert parsed_items[0]["end"] is None
+
+
+def test_time_notes():
+    # Assuming no specific time notes provided
+    assert parsed_items[0]["time_notes"] == ""
+
+
+def test_id():
+    # You'll need to adjust the expected ID based on how your spider generates it
+    assert parsed_items[0]["id"].startswith("newnj_nmc")
+
+
+def test_status():
+    # Assuming status needs to be assumed or calculated somehow
+    assert parsed_items[0]["status"] == TENTATIVE
+
+
+def test_location():
+    assert parsed_items[0]["location"] == {
+        "address": "City Hall, 920 Broad Street, Newark, NJ 07102",
+        "name": "Municipal Council Chamber",
+    }
+
+
+def test_source():
+    assert (
+        parsed_items[0]["source"]
+        == "https://newark.legistar.com/DepartmentDetail.aspx?ID=689&GUID=B3DBDA39-751C-4DD8-B443-ACC982CBFF09"  # noqa
+    )
+
+
+def test_links():
+    assert parsed_items[0]["links"] == [
+        {
+            "href": "https://newark.legistar.com/View.ashx?M=A&ID=1189588&GUID=C695B36D-A796-47DD-8140-118B4FFBA77F",  # noqa
+            "title": "Agenda",
+        }
+    ]
+
+
+def test_classification():
+    assert parsed_items[0]["classification"] == CITY_COUNCIL
+
+
+@pytest.mark.parametrize("item", parsed_items)
+def test_all_day(item):
+    assert item["all_day"] is False

--- a/tests/test_newnj_nmc.py
+++ b/tests/test_newnj_nmc.py
@@ -66,7 +66,7 @@ def test_location():
 def test_source():
     assert (
         parsed_items[0]["source"]
-        == "https://newark.legistar.com/DepartmentDetail.aspx?ID=689&GUID=B3DBDA39-751C-4DD8-B443-ACC982CBFF09"  # noqa
+        == "https://newark.legistar.com/MeetingDetail.aspx?ID=1189588&GUID=C695B36D-A796-47DD-8140-118B4FFBA77F&Options=info|&Search="  # noqa
     )
 
 


### PR DESCRIPTION
## What's this PR do?
Adds a spider to scrape meetings from the website of Newark Municipal Council. The new spider is called `newnj_nmc`.

## Why are we doing this?
Requested by our site partners.

## Steps to manually test

1. Ensure the project is installed:
```
pipenv sync --dev
```
2. Activate the virtual env and enter the pipenv shell:
```
pipenv shell
```
3. Run the spider:
```
scrapy crawl newnj_nmc -O test_output.csv
```
4. Monitor the output and ensure no errors are raised.

5. Inspect `test_output.csv` to ensure the data looks valid. Target website is [here]().

## Are there any smells or added technical debt to note?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207038636509886